### PR TITLE
When "cd" is executed: go to miniroot if set.

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -460,7 +460,12 @@ static int cd_main(int argc, char** argv) {
         }
     } else { // [cd] Help, I'm lost, bring me back home
         previousDirectory = [[NSFileManager defaultManager] currentDirectoryPath];
-        [[NSFileManager defaultManager] changeCurrentDirectoryPath:[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject]];
+
+        if (miniRoot != nil) {
+            [[NSFileManager defaultManager] changeCurrentDirectoryPath:miniRoot];
+        } else {
+            [[NSFileManager defaultManager] changeCurrentDirectoryPath:[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject]];
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Right now in Terminal, executing "cd" will bring the user to the local documents folder. This PR checks if miniroot is set, and if so: go there instead.