### PR TITLE
expose ios_isatty as public part of ios_system

### DIFF
--- a/ios_system/ios_system.h
+++ b/ios_system/ios_system.h
@@ -26,6 +26,7 @@ extern int ios_executable(const char* inputCmd); // does this command exist? (ex
 extern int ios_system(const char* inputCmd); // execute this command (executable file or builtin command)
 extern FILE *ios_popen(const char *command, const char *type); // Execute this command and pipe the result
 extern int ios_kill(void); // kill the current running command
+extern int ios_isatty(int fd); // test whether a file descriptor refers to a terminal
 
 extern NSString* commandsAsString(void);
 extern NSArray* commandsAsArray(void);      // set of all commands, in an NSArrays


### PR DESCRIPTION
Needed to make the open-url command in OpenTerm not wait on user input when reading from stdin:
 https://github.com/louisdh/openterm/issues/132