### PR TITLE
Move allowedPaths to global space from session

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -120,6 +120,7 @@ static void* run_function(void* parameters) {
 }
 
 static NSString* miniRoot = nil; // limit operations to below a certain directory (~, usually).
+static NSArray<NSString*> *allowedPaths = nil;
 static NSDictionary *commandList = nil;
 // do recompute directoriesInPath only if $PATH has changed
 static NSString* fullCommandPath = @"";
@@ -346,11 +347,7 @@ int ios_setMiniRootURL(NSURL* mRoot) {
 }
 
 int ios_setAllowedPaths(NSArray<NSString *> *paths) {
-  if (currentSession == nil) {
-    return 0;
-  }
-  
-  currentSession.allowedPaths = paths;
+  allowedPaths = paths;
   return 1;
 }
 
@@ -364,7 +361,7 @@ BOOL __allowed_cd_to_path(NSString *path) {
     return YES;
   }
   
-  for (NSString *dir in currentSession.allowedPaths) {
+  for (NSString *dir in allowedPaths) {
     if ([path hasPrefix:dir]) {
       return YES;
     }

--- a/ios_system/sessionParameters.h
+++ b/ios_system/sessionParameters.h
@@ -14,7 +14,6 @@
 @property NSString *currentDir;
 @property NSString *previousDirectory;
 @property NSURL    *localMiniRoot;
-@property NSArray<NSString*> *allowedPaths;
 @property pthread_t current_command_root_thread; // thread ID of first command
 @property pthread_t lastThreadId; // thread ID of last command
 @property FILE* stdin;

--- a/ios_system/sessionParameters.m
+++ b/ios_system/sessionParameters.m
@@ -19,7 +19,6 @@
     self.currentDir = [fileManager currentDirectoryPath];
     self.previousDirectory = [fileManager currentDirectoryPath];
     self.localMiniRoot = nil;
-    self.allowedPaths = nil;
     self.global_errno = 0;
     self.stdin = stdin;
     self.stdout = stdout;


### PR DESCRIPTION
Hi @holzschu,

After some sort of experimenting, you where right, it is better to keep allowedPaths at same level as miniRoot (not on session level)

This PR fixes that.