### PR TITLE
new relative paths to curl_ios_static

### DIFF
--- a/curl_ios_static.xcodeproj/project.pbxproj
+++ b/curl_ios_static.xcodeproj/project.pbxproj
@@ -1712,16 +1712,12 @@
 					curl/curl/lib/,
 					"-DBUILDING_LIBCURL",
 					"-I",
-					../blink/Settings/Model/,
+					../../Settings/Model/,
 					"-I",
-					../blink/Frameworks/libssh2.framework/Headers/,
-					"-DBLINKSHELL",
+					../libssh2.framework/Headers/,
 					"-I",
 					../ios_system/,
-				);
-				OTHER_LDFLAGS = (
-					"-F",
-					"../../libssh2-for-iOS/",
+					"-DBLINKSHELL",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "Acube.curl-ios";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1752,16 +1748,12 @@
 					curl/curl/lib/,
 					"-DBUILDING_LIBCURL",
 					"-I",
-					../blink/Settings/Model/,
+					../../Settings/Model/,
 					"-I",
-					../blink/Frameworks/libssh2.framework/Headers/,
-					"-DBLINKSHELL",
+					../libssh2.framework/Headers/,
 					"-I",
 					../ios_system/,
-				);
-				OTHER_LDFLAGS = (
-					"-F",
-					"../../libssh2-for-iOS/",
+					"-DBLINKSHELL",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "Acube.curl-ios";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
We moved ios_system to <root>/Frameworks/ios_system as submodule

This commit fix relative paths to it. Since curl_ios_static project is for blink (for now), I'd like to sync project settings. 