### PR TITLE
scp fixes for Blink. Grab remote port setting from config and try to use blink id_rsa and id_dsa keys

### DIFF
--- a/curl.patch
+++ b/curl.patch
@@ -713,7 +713,7 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
        }
 diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
 --- curl-105/curl/lib/url.c	2017-05-17 22:04:33.000000000 +0300
-+++ curl/curl/lib/url.c	2018-10-02 16:22:45.000000000 +0300
++++ curl/curl/lib/url.c	2018-10-03 13:35:04.000000000 +0300
 @@ -119,6 +119,18 @@
  #include "pipeline.h"
  #include "dotdot.h"
@@ -827,7 +827,7 @@ diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
 +                *userp = strdup([host.user UTF8String]);
 +            }
 +            // grab remote port from host settings too
-+            if (host.port.intValue) {
++            if (conn->remote_port == -1 && host.port.intValue) {
 +                conn->remote_port = host.port.intValue;
 +            }
 +        }

--- a/curl.patch
+++ b/curl.patch
@@ -1,6 +1,6 @@
 diff -Naur curl-105/Info.plist curl/Info.plist
---- curl-105/Info.plist	1970-01-01 01:00:00.000000000 +0100
-+++ curl/Info.plist	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/Info.plist	1970-01-01 03:00:00.000000000 +0300
++++ curl/Info.plist	2018-10-02 15:43:52.000000000 +0300
 @@ -0,0 +1,24 @@
 +<?xml version="1.0" encoding="UTF-8"?>
 +<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -27,8 +27,8 @@ diff -Naur curl-105/Info.plist curl/Info.plist
 +</dict>
 +</plist>
 diff -Naur curl-105/config_iphone/curl_config.h curl/config_iphone/curl_config.h
---- curl-105/config_iphone/curl_config.h	2017-05-24 02:47:37.000000000 +0200
-+++ curl/config_iphone/curl_config.h	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/config_iphone/curl_config.h	2017-05-24 03:47:37.000000000 +0300
++++ curl/config_iphone/curl_config.h	2018-10-02 15:43:52.000000000 +0300
 @@ -410,6 +410,7 @@
  
  /* Define to 1 if you have the <libssh2.h> header file. */
@@ -63,8 +63,8 @@ diff -Naur curl-105/config_iphone/curl_config.h curl/config_iphone/curl_config.h
  /* if NSS is enabled */
  /* #undef USE_NSS */
 diff -Naur curl-105/curl/include/curl/curl.h curl/curl/include/curl/curl.h
---- curl-105/curl/include/curl/curl.h	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/include/curl/curl.h	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/include/curl/curl.h	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/include/curl/curl.h	2018-10-02 15:43:52.000000000 +0300
 @@ -2391,7 +2391,7 @@
                             callback functions */
    CURLSHOPT_LAST  /* never use */
@@ -75,8 +75,8 @@ diff -Naur curl-105/curl/include/curl/curl.h curl/curl/include/curl/curl.h
  CURL_EXTERN CURLSHcode curl_share_setopt(CURLSH *, CURLSHoption option, ...);
  CURL_EXTERN CURLSHcode curl_share_cleanup(CURLSH *);
 diff -Naur curl-105/curl/lib/conncache.c curl/curl/lib/conncache.c
---- curl-105/curl/lib/conncache.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/conncache.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/conncache.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/conncache.c	2018-10-02 15:43:52.000000000 +0300
 @@ -335,7 +335,7 @@
    if(!connc)
      return;
@@ -106,8 +106,8 @@ diff -Naur curl-105/curl/lib/conncache.c curl/curl/lib/conncache.c
      he = Curl_hash_next_element(&iter);
    }
 diff -Naur curl-105/curl/lib/cookie.c curl/curl/lib/cookie.c
---- curl-105/curl/lib/cookie.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/cookie.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/cookie.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/cookie.c	2018-10-02 15:43:52.000000000 +0300
 @@ -81,6 +81,7 @@
  
  
@@ -135,8 +135,8 @@ diff -Naur curl-105/curl/lib/cookie.c curl/curl/lib/cookie.c
    }
    else {
 diff -Naur curl-105/curl/lib/curl_ntlm_wb.c curl/curl/lib/curl_ntlm_wb.c
---- curl-105/curl/lib/curl_ntlm_wb.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/curl_ntlm_wb.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/curl_ntlm_wb.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/curl_ntlm_wb.c	2018-10-02 15:43:52.000000000 +0300
 @@ -52,6 +52,7 @@
  #include "url.h"
  #include "strerror.h"
@@ -181,8 +181,8 @@ diff -Naur curl-105/curl/lib/curl_ntlm_wb.c curl/curl/lib/curl_ntlm_wb.c
      authp->done = TRUE;
      Curl_ntlm_wb_cleanup(conn);
 diff -Naur curl-105/curl/lib/easy.c curl/curl/lib/easy.c
---- curl-105/curl/lib/easy.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/easy.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/easy.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/easy.c	2018-10-02 15:43:52.000000000 +0300
 @@ -216,31 +216,31 @@
  
    if(flags & CURL_GLOBAL_SSL)
@@ -275,8 +275,8 @@ diff -Naur curl-105/curl/lib/easy.c curl/curl/lib/easy.c
                                         &ev->running_handles);
      }
 diff -Naur curl-105/curl/lib/formdata.c curl/curl/lib/formdata.c
---- curl-105/curl/lib/formdata.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/formdata.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/formdata.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/formdata.c	2018-10-02 15:43:52.000000000 +0300
 @@ -37,6 +37,8 @@
  #include "sendf.h"
  #include "strdup.h"
@@ -305,8 +305,8 @@ diff -Naur curl-105/curl/lib/formdata.c curl/curl/lib/formdata.c
              fclose(fileread);
              /* add the file name only - for later reading from this */
 diff -Naur curl-105/curl/lib/hash.c curl/curl/lib/hash.c
---- curl-105/curl/lib/hash.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/hash.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/hash.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/hash.c	2018-10-02 15:43:52.000000000 +0300
 @@ -336,16 +336,16 @@
    if(!h)
      return;
@@ -341,8 +341,8 @@ diff -Naur curl-105/curl/lib/hash.c curl/curl/lib/hash.c
  }
  #endif
 diff -Naur curl-105/curl/lib/hostip6.c curl/curl/lib/hostip6.c
---- curl-105/curl/lib/hostip6.c	2016-11-04 22:42:50.000000000 +0100
-+++ curl/curl/lib/hostip6.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/hostip6.c	2016-11-05 00:42:50.000000000 +0300
++++ curl/curl/lib/hostip6.c	2018-10-02 15:43:52.000000000 +0300
 @@ -132,16 +132,16 @@
  #ifdef DEBUG_ADDRINFO
  static void dump_addrinfo(struct connectdata *conn, const Curl_addrinfo *ai)
@@ -365,8 +365,8 @@ diff -Naur curl-105/curl/lib/hostip6.c curl/curl/lib/hostip6.c
  }
  #else
 diff -Naur curl-105/curl/lib/http_ntlm.c curl/curl/lib/http_ntlm.c
---- curl-105/curl/lib/http_ntlm.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/http_ntlm.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/http_ntlm.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/http_ntlm.c	2018-10-02 15:43:52.000000000 +0300
 @@ -184,7 +184,7 @@
        if(!*allocuserpwd)
          return CURLE_OUT_OF_MEMORY;
@@ -386,8 +386,8 @@ diff -Naur curl-105/curl/lib/http_ntlm.c curl/curl/lib/http_ntlm.c
        ntlm->state = NTLMSTATE_TYPE3; /* we send a type-3 */
        authp->done = TRUE;
 diff -Naur curl-105/curl/lib/ldap.c curl/curl/lib/ldap.c
---- curl-105/curl/lib/ldap.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/ldap.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/ldap.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/ldap.c	2018-10-02 15:43:52.000000000 +0300
 @@ -702,7 +702,7 @@
      return;
  
@@ -398,8 +398,8 @@ diff -Naur curl-105/curl/lib/ldap.c curl/curl/lib/ldap.c
  }
  #endif
 diff -Naur curl-105/curl/lib/memdebug.c curl/curl/lib/memdebug.c
---- curl-105/curl/lib/memdebug.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/memdebug.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/memdebug.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/memdebug.c	2018-10-02 15:43:52.000000000 +0300
 @@ -116,7 +116,7 @@
      if(logname && *logname)
        logfile = fopen(logname, FOPEN_WRITETEXT);
@@ -419,8 +419,8 @@ diff -Naur curl-105/curl/lib/memdebug.c curl/curl/lib/memdebug.c
          fflush(logfile); /* because it might crash now */
        }
 diff -Naur curl-105/curl/lib/mprintf.c curl/curl/lib/mprintf.c
---- curl-105/curl/lib/mprintf.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/mprintf.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/mprintf.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/mprintf.c	2018-10-02 15:43:52.000000000 +0300
 @@ -39,6 +39,7 @@
  #include <curl/mprintf.h>
  
@@ -448,8 +448,8 @@ diff -Naur curl-105/curl/lib/mprintf.c curl/curl/lib/mprintf.c
  
  int curl_mvfprintf(FILE *whereto, const char *format, va_list ap_save)
 diff -Naur curl-105/curl/lib/multi.c curl/curl/lib/multi.c
---- curl-105/curl/lib/multi.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/multi.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/multi.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/multi.c	2018-10-02 15:43:52.000000000 +0300
 @@ -474,7 +474,7 @@
  {
    struct Curl_sh_entry *sh = (struct Curl_sh_entry *)p;
@@ -496,8 +496,8 @@ diff -Naur curl-105/curl/lib/multi.c curl/curl/lib/multi.c
    }
  }
 diff -Naur curl-105/curl/lib/netrc.c curl/curl/lib/netrc.c
---- curl-105/curl/lib/netrc.c	2016-11-04 22:42:50.000000000 +0100
-+++ curl/curl/lib/netrc.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/netrc.c	2016-11-05 00:42:50.000000000 +0300
++++ curl/curl/lib/netrc.c	2018-10-02 15:43:52.000000000 +0300
 @@ -69,7 +69,8 @@
  
    if(!netrcfile) {
@@ -509,8 +509,8 @@ diff -Naur curl-105/curl/lib/netrc.c curl/curl/lib/netrc.c
        home_alloc = TRUE;
  #if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
 diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
---- curl-105/curl/lib/ssh.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/ssh.c	2018-05-04 15:22:00.000000000 +0200
+--- curl-105/curl/lib/ssh.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/ssh.c	2018-10-02 15:43:52.000000000 +0300
 @@ -26,6 +26,13 @@
  
  #ifdef USE_LIBSSH2
@@ -707,8 +707,8 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
          break;
        }
 diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
---- curl-105/curl/lib/url.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/url.c	2018-05-04 15:22:56.000000000 +0200
+--- curl-105/curl/lib/url.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/url.c	2018-10-02 15:47:08.000000000 +0300
 @@ -119,6 +119,18 @@
  #include "pipeline.h"
  #include "dotdot.h"
@@ -802,7 +802,7 @@ diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
      return CURLE_OK;
    }
  
-@@ -4630,6 +4642,18 @@
+@@ -4630,6 +4642,22 @@
     * Parse the login details from the URL and strip them out of
     * the host name
     */
@@ -814,6 +814,10 @@ diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
 +            if ([host.user length]) {
 +                *userp = strdup([host.user UTF8String]);
 +            }
++            // grab remote port from host settings too
++            if (host.port.intValue) {
++                conn->remote_port = host.port.intValue;
++            }
 +        }
 +    }
 +#endif
@@ -821,7 +825,7 @@ diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
    result = parse_url_login(data, conn, userp, passwdp, optionsp);
    if(result)
      return result;
-@@ -6875,7 +6899,7 @@
+@@ -6875,7 +6903,7 @@
     */
  
    if((data->set.out)->_handle == NULL) {
@@ -831,8 +835,8 @@ diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
  #endif
  
 diff -Naur curl-105/curl/lib/vauth/ntlm.c curl/curl/lib/vauth/ntlm.c
---- curl-105/curl/lib/vauth/ntlm.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/vauth/ntlm.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/vauth/ntlm.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/vauth/ntlm.c	2018-10-02 15:43:52.000000000 +0300
 @@ -141,9 +141,9 @@
  
    (void) handle;
@@ -926,8 +930,8 @@ diff -Naur curl-105/curl/lib/vauth/ntlm.c curl/curl/lib/vauth/ntlm.c
  
    /* Make sure that the domain, user and host strings fit in the
 diff -Naur curl-105/curl/lib/vtls/gtls.c curl/curl/lib/vtls/gtls.c
---- curl-105/curl/lib/vtls/gtls.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/vtls/gtls.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/vtls/gtls.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/lib/vtls/gtls.c	2018-10-02 15:43:52.000000000 +0300
 @@ -77,7 +77,7 @@
  #ifdef GTLSDEBUG
  static void tls_log_func(int level, const char *str)
@@ -938,8 +942,8 @@ diff -Naur curl-105/curl/lib/vtls/gtls.c curl/curl/lib/vtls/gtls.c
  #endif
  static bool gtls_inited = FALSE;
 diff -Naur curl-105/curl/lib/vtls/polarssl_threadlock.c curl/curl/lib/vtls/polarssl_threadlock.c
---- curl-105/curl/lib/vtls/polarssl_threadlock.c	2016-11-04 22:42:50.000000000 +0100
-+++ curl/curl/lib/vtls/polarssl_threadlock.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/lib/vtls/polarssl_threadlock.c	2016-11-05 00:42:50.000000000 +0300
++++ curl/curl/lib/vtls/polarssl_threadlock.c	2018-10-02 15:43:52.000000000 +0300
 @@ -107,7 +107,7 @@
    if(n < NUMT) {
      ret = pthread_mutex_lock(&mutex_buf[n]);
@@ -977,8 +981,8 @@ diff -Naur curl-105/curl/lib/vtls/polarssl_threadlock.c curl/curl/lib/vtls/polar
        return 0; /* pthread_mutex_lock failed */
      }
 diff -Naur curl-105/curl/src/tool_cb_dbg.c curl/curl/src/tool_cb_dbg.c
---- curl-105/curl/src/tool_cb_dbg.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_cb_dbg.c	2018-04-23 20:32:49.000000000 +0200
+--- curl-105/curl/src/tool_cb_dbg.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_cb_dbg.c	2018-10-02 15:43:52.000000000 +0300
 @@ -29,6 +29,7 @@
  #include "tool_msgs.h"
  #include "tool_cb_dbg.h"
@@ -1006,8 +1010,8 @@ diff -Naur curl-105/curl/src/tool_cb_dbg.c curl/curl/src/tool_cb_dbg.c
              fprintf(output, "%s%s ", timebuf, s_infotype[type]);
            fprintf(output, "[%zd bytes data]\n", size);
 diff -Naur curl-105/curl/src/tool_easysrc.c curl/curl/src/tool_easysrc.c
---- curl-105/curl/src/tool_easysrc.c	2016-07-06 23:44:05.000000000 +0200
-+++ curl/curl/src/tool_easysrc.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_easysrc.c	2016-07-07 00:44:05.000000000 +0300
++++ curl/curl/src/tool_easysrc.c	2018-10-02 15:43:52.000000000 +0300
 @@ -32,6 +32,7 @@
  #include "tool_cfgable.h"
  #include "tool_easysrc.h"
@@ -1026,8 +1030,8 @@ diff -Naur curl-105/curl/src/tool_easysrc.c curl/curl/src/tool_easysrc.c
      warnf(config, "Failed to open %s to write libcurl code!\n", o);
    else {
 diff -Naur curl-105/curl/src/tool_getparam.c curl/curl/src/tool_getparam.c
---- curl-105/curl/src/tool_getparam.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_getparam.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_getparam.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_getparam.c	2018-10-02 15:43:52.000000000 +0300
 @@ -38,6 +38,7 @@
  #include "tool_msgs.h"
  #include "tool_paramhlp.h"
@@ -1104,8 +1108,8 @@ diff -Naur curl-105/curl/src/tool_getparam.c curl/curl/src/tool_getparam.c
          if(err)
            return err;
 diff -Naur curl-105/curl/src/tool_getpass.c curl/curl/src/tool_getpass.c
---- curl-105/curl/src/tool_getpass.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_getpass.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_getpass.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_getpass.c	2018-10-02 15:43:52.000000000 +0300
 @@ -56,6 +56,7 @@
  #include <unistd.h>
  #endif
@@ -1187,8 +1191,8 @@ diff -Naur curl-105/curl/src/tool_getpass.c curl/curl/src/tool_getpass.c
  
    return password; /* return pointer to buffer */
 diff -Naur curl-105/curl/src/tool_help.c curl/curl/src/tool_help.c
---- curl-105/curl/src/tool_help.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_help.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_help.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_help.c	2018-10-02 15:43:52.000000000 +0300
 @@ -25,6 +25,7 @@
  #include "tool_help.h"
  #include "tool_libinfo.h"
@@ -1241,8 +1245,8 @@ diff -Naur curl-105/curl/src/tool_help.c curl/curl/src/tool_help.c
    else {
      puts("  <none>");
 diff -Naur curl-105/curl/src/tool_hugehelp.c curl/curl/src/tool_hugehelp.c
---- curl-105/curl/src/tool_hugehelp.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_hugehelp.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_hugehelp.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_hugehelp.c	2018-10-02 15:43:52.000000000 +0300
 @@ -1,4 +1,5 @@
  #include "tool_setup.h"
 +#include "ios_error.h"
@@ -4886,8 +4890,8 @@ diff -Naur curl-105/curl/src/tool_hugehelp.c curl/curl/src/tool_hugehelp.c
            break;
        }
 diff -Naur curl-105/curl/src/tool_main.c curl/curl/src/tool_main.c
---- curl-105/curl/src/tool_main.c	2016-07-06 23:44:05.000000000 +0200
-+++ curl/curl/src/tool_main.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_main.c	2016-07-07 00:44:05.000000000 +0300
++++ curl/curl/src/tool_main.c	2018-10-02 15:43:52.000000000 +0300
 @@ -44,6 +44,7 @@
  #include "tool_vms.h"
  #include "tool_main.h"
@@ -5061,8 +5065,8 @@ diff -Naur curl-105/curl/src/tool_main.c curl/curl/src/tool_main.c
    struct GlobalConfig global;
    memset(&global, 0, sizeof(global));
 diff -Naur curl-105/curl/src/tool_main.h curl/curl/src/tool_main.h
---- curl-105/curl/src/tool_main.h	2016-07-06 23:44:05.000000000 +0200
-+++ curl/curl/src/tool_main.h	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_main.h	2016-07-07 00:44:05.000000000 +0300
++++ curl/curl/src/tool_main.h	2018-10-02 15:43:52.000000000 +0300
 @@ -29,15 +29,15 @@
  #define RETRY_SLEEP_MAX     600000L /* ms == 10 minutes */
  
@@ -5083,8 +5087,8 @@ diff -Naur curl-105/curl/src/tool_main.h curl/curl/src/tool_main.h
  
  #endif /* HEADER_CURL_TOOL_MAIN_H */
 diff -Naur curl-105/curl/src/tool_operate.c curl/curl/src/tool_operate.c
---- curl-105/curl/src/tool_operate.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_operate.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_operate.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_operate.c	2018-10-02 15:43:52.000000000 +0300
 @@ -40,6 +40,10 @@
  #endif
  
@@ -5192,8 +5196,8 @@ diff -Naur curl-105/curl/src/tool_operate.c curl/curl/src/tool_operate.c
            /* if retry-max-time is non-zero, make sure we haven't exceeded the
               time */
 diff -Naur curl-105/curl/src/tool_parsecfg.c curl/curl/src/tool_parsecfg.c
---- curl-105/curl/src/tool_parsecfg.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_parsecfg.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_parsecfg.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_parsecfg.c	2018-10-02 15:43:52.000000000 +0300
 @@ -31,6 +31,7 @@
  #include "tool_homedir.h"
  #include "tool_msgs.h"
@@ -5239,8 +5243,8 @@ diff -Naur curl-105/curl/src/tool_parsecfg.c curl/curl/src/tool_parsecfg.c
    }
    else
 diff -Naur curl-105/curl/src/tool_urlglob.c curl/curl/src/tool_urlglob.c
---- curl-105/curl/src/tool_urlglob.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_urlglob.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_urlglob.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_urlglob.c	2018-10-02 15:43:52.000000000 +0300
 @@ -28,6 +28,7 @@
  #include "tool_doswin.h"
  #include "tool_urlglob.h"
@@ -5277,8 +5281,8 @@ diff -Naur curl-105/curl/src/tool_urlglob.c curl/curl/src/tool_urlglob.c
            Curl_safefree(target);
            return CURLE_FAILED_INIT;
 diff -Naur curl-105/curl/src/tool_vms.c curl/curl/src/tool_vms.c
---- curl-105/curl/src/tool_vms.c	2016-07-06 23:44:05.000000000 +0200
-+++ curl/curl/src/tool_vms.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_vms.c	2016-07-07 00:44:05.000000000 +0300
++++ curl/curl/src/tool_vms.c	2018-10-02 15:43:52.000000000 +0300
 @@ -178,14 +178,14 @@
        }
        else {
@@ -5297,8 +5301,8 @@ diff -Naur curl-105/curl/src/tool_vms.c curl/curl/src/tool_vms.c
  
    }
 diff -Naur curl-105/curl/src/tool_writeout.c curl/curl/src/tool_writeout.c
---- curl-105/curl/src/tool_writeout.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_writeout.c	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl/src/tool_writeout.c	2017-05-17 22:04:33.000000000 +0300
++++ curl/curl/src/tool_writeout.c	2018-10-02 15:43:52.000000000 +0300
 @@ -25,6 +25,7 @@
  #include "curlx.h"
  #include "tool_cfgable.h"
@@ -5326,8 +5330,8 @@ diff -Naur curl-105/curl/src/tool_writeout.c curl/curl/src/tool_writeout.c
            ptr = end + 1; /* pass the end */
            *end = keepit;
 diff -Naur curl-105/curl.h curl/curl.h
---- curl-105/curl.h	1970-01-01 01:00:00.000000000 +0100
-+++ curl/curl.h	2018-04-23 20:32:50.000000000 +0200
+--- curl-105/curl.h	1970-01-01 03:00:00.000000000 +0300
++++ curl/curl.h	2018-10-02 15:43:52.000000000 +0300
 @@ -0,0 +1,19 @@
 +//
 +//  curl.h

--- a/curl.patch
+++ b/curl.patch
@@ -510,7 +510,7 @@ diff -Naur curl-105/curl/lib/netrc.c curl/curl/lib/netrc.c
  #if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
 diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
 --- curl-105/curl/lib/ssh.c	2017-05-17 22:04:33.000000000 +0300
-+++ curl/curl/lib/ssh.c	2018-10-02 15:43:52.000000000 +0300
++++ curl/curl/lib/ssh.c	2018-10-02 16:22:42.000000000 +0300
 @@ -26,6 +26,13 @@
  
  #ifdef USE_LIBSSH2
@@ -559,7 +559,7 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
  
    do {
  
-@@ -810,11 +827,59 @@
+@@ -810,13 +827,63 @@
  
          /* To ponder about: should really the lib be messing about with the
             HOME environment variable etc? */
@@ -601,28 +601,33 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
 +                      }
 +                  }
 +              }
-+              if (!(privateKeyMemory && publicKeyMemory)) {
-+                  // Priority 2: key named id_rsa:
-+                  if ((pk = [BKPubKey withID:@"id_rsa"]) != nil) {
-+                      publicKeyMemory = [pk.publicKey UTF8String];
-+                      privateKeyMemory = [pk.privateKey UTF8String];
-+                      sshc->rsa = strdup("id_rsa");
-+                  }
-+              }
-+              if (!(privateKeyMemory && publicKeyMemory)) {
-+                  // Still no luck, try with id_dsa:
-+                  if ((pk = [BKPubKey withID:@"id_dsa"]) != nil) {
-+                      publicKeyMemory = [pk.publicKey UTF8String];
-+                      privateKeyMemory = [pk.privateKey UTF8String];
-+                      sshc->rsa = strdup("id_dsa");
-+                  }
-+              }
++            
 +          } else {
++
++            if (!(privateKeyMemory && publicKeyMemory)) {
++              // Priority 2: key named id_rsa:
++              if ((pk = [BKPubKey withID:@"id_rsa"]) != nil) {
++                publicKeyMemory = [pk.publicKey UTF8String];
++                privateKeyMemory = [pk.privateKey UTF8String];
++                sshc->rsa = strdup("id_rsa");
++              }
++            }
++            if (!(privateKeyMemory && publicKeyMemory)) {
++              // Still no luck, try with id_dsa:
++              if ((pk = [BKPubKey withID:@"id_dsa"]) != nil) {
++                publicKeyMemory = [pk.publicKey UTF8String];
++                privateKeyMemory = [pk.privateKey UTF8String];
++                sshc->rsa = strdup("id_dsa");
++              }
++            }
 +#endif
            /* If no private key file is specified, try some common paths. */
-           if(home) {
+-          if(home) {
++          if(home && !sshc->rsa) {
              /* Try ~/.ssh first. */
-@@ -831,6 +896,9 @@
+             sshc->rsa = aprintf("%s/.ssh/id_rsa", home);
+             if(!sshc->rsa)
+@@ -831,6 +898,9 @@
                }
              }
            }
@@ -632,7 +637,7 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
            if(!out_of_memory && !sshc->rsa) {
              /* Nothing found; try the current dir. */
              sshc->rsa = strdup("id_rsa");
-@@ -852,6 +920,9 @@
+@@ -852,6 +922,9 @@
           * libssh2 extract the public key from the private key file.
           * This is done by simply passing sshc->rsa_pub = NULL.
           */
@@ -642,7 +647,7 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
          if(data->set.str[STRING_SSH_PUBLIC_KEY]
              /* treat empty string the same way as NULL */
              && data->set.str[STRING_SSH_PUBLIC_KEY][0]) {
-@@ -859,6 +930,9 @@
+@@ -859,6 +932,9 @@
            if(!sshc->rsa_pub)
              out_of_memory = TRUE;
          }
@@ -652,7 +657,7 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
  
          if(out_of_memory || sshc->rsa == NULL) {
            free(home);
-@@ -869,15 +943,22 @@
+@@ -869,15 +945,22 @@
            break;
          }
  
@@ -678,7 +683,7 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
  
          state(conn, SSH_AUTH_PKEY);
        }
-@@ -889,12 +970,25 @@
+@@ -889,12 +972,25 @@
      case SSH_AUTH_PKEY:
        /* The function below checks if the files exists, no need to stat() here.
         */
@@ -708,7 +713,7 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
        }
 diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
 --- curl-105/curl/lib/url.c	2017-05-17 22:04:33.000000000 +0300
-+++ curl/curl/lib/url.c	2018-10-02 15:47:08.000000000 +0300
++++ curl/curl/lib/url.c	2018-10-02 16:22:45.000000000 +0300
 @@ -119,6 +119,18 @@
  #include "pipeline.h"
  #include "dotdot.h"
@@ -802,7 +807,14 @@ diff -Naur curl-105/curl/lib/url.c curl/curl/lib/url.c
      return CURLE_OK;
    }
  
-@@ -4630,6 +4642,22 @@
+@@ -4624,12 +4636,28 @@
+ 
+   result = findprotocol(data, conn, protop);
+   if(result)
+-    return result;
++    return
+ 
+   /*
     * Parse the login details from the URL and strip them out of
     * the host name
     */


### PR DESCRIPTION
Hi @holzschu!

Not sure I did right patching thing. But this patch adds port configuration from blink hosts config for scp.

```
#ifdef BLINKSHELL // get user and host from Blinkshell config
    if ((strcmp(protop, "scp") == 0) || (strcmp(protop, "sftp") == 0)) {
        BKHosts *host;
        if (host = [BKHosts withHost:[NSString stringWithUTF8String:conn->host.name]]) {
            if (host.hostName) conn->host.name = [host.hostName UTF8String];
            if ([host.user length]) {
                *userp = strdup([host.user UTF8String]);
            }
            // grab remote port from host settings too
            if (host.port.intValue) {
                conn->remote_port = host.port.intValue;
            }
        }
    }
#endif
```