### PR TITLE
Handle crashes in commands

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -128,7 +128,7 @@ static void cleanup_function(void* parameters) {
 }
 
 void crash_handler(int sig) {
-    NSLog(@"Received signal: %i", sig);
+    fputs("segmentation fault\n", thread_stderr);
     ios_exit(1);
 }
 

--- a/ios_system.m
+++ b/ios_system.m
@@ -127,6 +127,11 @@ static void cleanup_function(void* parameters) {
     ios_releaseThread(pthread_self());
 }
 
+void crash_handler(int sig) {
+    NSLog(@"Received signal: %i", sig);
+    ios_exit(1);
+}
+
 static void* run_function(void* parameters) {
     ios_storeThreadId(pthread_self());
     // re-initialize for getopt:
@@ -141,6 +146,10 @@ static void* run_function(void* parameters) {
     thread_stdout = p->stdout;
     thread_stderr = p->stderr;
     thread_context = p->context;
+    
+    signal(SIGSEGV, crash_handler);
+    signal(SIGBUS, crash_handler);
+    
     // Because some commands change argv, keep a local copy for release.
     p->argv_ref = (char **)malloc(sizeof(char*) * (p->argc + 1));
     for (int i = 0; i < p->argc; i++) p->argv_ref[i] = p->argv[i];

--- a/ios_system.m
+++ b/ios_system.m
@@ -128,7 +128,11 @@ static void cleanup_function(void* parameters) {
 }
 
 void crash_handler(int sig) {
-    fputs("segmentation fault\n", thread_stderr);
+    if (sig == SIGSEGV) {
+        fputs("segmentation fault\n", thread_stderr);
+    } else if (sig == SIGBUS) {
+        fputs("bus error\n", thread_stderr);
+    }
     ios_exit(1);
 }
 


### PR DESCRIPTION
I called `signal` to handle `SIGSEGV`and `SIGBUS` signals in commands so code typed by the user doesn't make the app crash. I tested running a program that would make the app crash with `lli` and it works (not only the first time, but every time). `lli` prints a stack dump so it's clear the program crashed. When debugging with Xcode, the app crashes even with the signal handler.

![Screenshot 2019-09-04 at 17 51 17](https://user-images.githubusercontent.com/19255527/64294472-e8121f80-cf3c-11e9-879e-4b484e293dda.png)
