### PR TITLE
do not strip static lib

### DIFF
--- a/curl_ios_static.xcodeproj/project.pbxproj
+++ b/curl_ios_static.xcodeproj/project.pbxproj
@@ -1722,6 +1722,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Acube.curl-ios";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
 				STRIP_STYLE = "non-global";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1758,6 +1759,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Acube.curl-ios";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
 				STRIP_STYLE = "non-global";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};


### PR DESCRIPTION
without `STRIP_INSTALLED_PRODUCT = NO;` Xcode fails to archive project.