### PR TITLE
Use base name instead of full path in ios_executable()

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -604,7 +604,11 @@ NSString* operatesOn(NSString* commandName) {
 int ios_executable(const char* inputCmd) {
     // returns 1 if this is one of the commands we define in ios_system, 0 otherwise
     if (commandList == nil) initializeCommandList();
-    NSArray* valuesFromDict = [commandList objectForKey: [NSString stringWithCString:inputCmd encoding:NSUTF8StringEncoding]];
+
+    // For our commands (e.g. $SYSROOT/usr/bin/clang)
+    const char* command = basename(inputCmd);
+
+    NSArray* valuesFromDict = [commandList objectForKey: [NSString stringWithCString:command encoding:NSUTF8StringEncoding]];
     // we could dlopen() here, but that would defeat the purpose
     if (valuesFromDict == nil) return 0;
     else return 1;


### PR DESCRIPTION
I changed `ios_executable()` function to use a base name instead of a full path.

For example, `clang` for ios_system internally executes `$SYSROOT/usr/bin/clang` because of [this changes](https://github.com/holzschu/clang/commit/ebd095683ad3789a09118d6897c887c45af037f8) but the current `ios_executable()` compares a full path of an input command to keys of `commandList`.

Thus, if I run `clang`, it shows an error like `Executable "/private/var/.../a-Shell.app/usr/bin/clang" doesn't exist!`. On the other side, `ios_system()` uses `basename()`in [this line](https://github.com/holzschu/ios_system/blob/a317ed0917f73effb9530f8e0b147c21b17bbdf3/ios_system.m#L1670) for that reason. So, I imitated it.