### PR TITLE
Cleanup imports.

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -5,7 +5,9 @@
 //  Copyright © 2017 N. Holzschuch. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+
+#import <UIKit/UIKit.h>
+
 #include "ios_system.h"
 
 // ios_system(cmd): Executes the command in "cmd". The goal is to be a drop-in replacement for system(), as much as possible.

--- a/ios_system/ios_system.h
+++ b/ios_system/ios_system.h
@@ -7,8 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
-#import <WebKit/WebKit.h>
 
 //! Project version number for ios_system.
 FOUNDATION_EXPORT double ios_systemVersionNumber;

--- a/shell_cmds_ios/open.m
+++ b/shell_cmds_ios/open.m
@@ -8,7 +8,8 @@
 #include <stdio.h>
 #include "ios_system/ios_system.h"
 #include "ios_error.h"
-#import <Foundation/Foundation.h>
+
+#import <UIKit/UIKit.h>
 
 
 NSArray<NSString *> *__known_browsers() {


### PR DESCRIPTION
- No need for WebKit as a core dep. Some platforms (tv and watch) doesn't support it
- No need for UIKit in public header.