### PR TITLE
Valid zips

### DIFF
--- a/xcfs/Package.swift
+++ b/xcfs/Package.swift
@@ -12,13 +12,13 @@ _ = Package(
         // ssh_cmd, curl_ios
         .binaryTarget(
             name: "libssh2",
-            url: "https://github.com/yury/libssh2-apple/releases/download/v1.9.0/libssh2-dynamic.xcframework.zip",
-            checksum: "07952e484eb511b1badb110c15d4621bb84ef98b28ea4d6e1d3a067d420806f5"
+            url: "https://github.com/blinksh/libssh2-apple/releases/download/v1.9.0/libssh2-dynamic.xcframework.zip",
+            checksum: "79b18673040a51e7c62259965c2310b5df2a686de83b9cc94c54db944621c32c"
         ),
         .binaryTarget(
             name: "openssl",
-            url: "https://github.com/yury/openssl-apple/releases/download/v1.1.1i/openssl-dynamic.xcframework.zip",
-            checksum: "d07917d2db5480add458a7373bb469b2e46e9aba27ab0ebd3ddc8654df58e60f"
+            url: "https://github.com/blinksh/openssl-apple/releases/download/v1.1.1i/openssl-dynamic.xcframework.zip",
+            checksum: "7f7e7cf7a1717dde6fdc71ef62c24e782f3c0ca1a2621e9376699362da990993"
         ),
 
         .target(

--- a/xcfs/Sources/build/main.swift
+++ b/xcfs/Sources/build/main.swift
@@ -41,7 +41,7 @@ for scheme in schemes {
 
     try cd(".build") {
         let zip = "\(scheme).xcframework.zip"
-        try sh("zip -r \(zip) \(scheme).xcframework")
+        try sh("zip --symlinks -r \(zip) \(scheme).xcframework")
         let chksum = try sha(path: zip)
         checksums.append([zip, chksum])
     }


### PR DESCRIPTION
Hello,

Sorry for bombarding you with PRs. But I found issue with zipping XCFrameworks with Catalyst. Turns out zip by default expands symlink. MacOSX and Catalyst frameworks use symlinks inside, so the have doubled everything inside and the worst part - Xcode can't sign them.

So I added `--symlinks` flag to `zip`. I tested everything and now they are really good Catalyst frameworks.

Will make PR for network_ios too