### PR TITLE
Add function getters for __thread vars

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -51,6 +51,22 @@ __thread FILE* thread_stdout;
 __thread FILE* thread_stderr;
 __thread void* thread_context;
 
+FILE* ios_stdin(void) {
+    return thread_stdin;
+}
+
+FILE* ios_stdout(void) {
+    return thread_stdout;
+}
+
+FILE* ios_stderr(void) {
+    return thread_stderr;
+}
+
+void* ios_context(void) {
+    return thread_context;
+}
+
 // Parameters for each session. We can have multiple sessions running in parallel.
 typedef struct _sessionParameters {
     bool isMainThread;   // are we on the first command?

--- a/ios_system/ios_system.h
+++ b/ios_system/ios_system.h
@@ -20,6 +20,15 @@ extern __thread FILE* thread_stdin;
 extern __thread FILE* thread_stdout;
 extern __thread FILE* thread_stderr;
 extern __thread void* thread_context;
+
+// rust doesn't support extern __thread vars yet
+// see https://github.com/rust-lang/rust/issues/30795
+// so we provide function accessors for them.
+extern FILE* ios_stdin(void);
+extern FILE* ios_stdout(void);
+extern FILE* ios_stderr(void);
+extern void* ios_context(void);
+
 // set to true to have more commands available, more debugging information.
 extern bool sideLoading;
 // set to false to have the main thread run in detached mode (non blocking)


### PR DESCRIPTION
Hello,

Turns out `rust` doesn't provide clean way to use external __pthread vars. So I added getters for them.

Also added convenient fd getters.