### PR TITLE
Increase maximum columns and rows.

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -83,8 +83,8 @@ typedef struct _sessionParameters {
     void* context;
     int global_errno;
     char commandName[NAME_MAX];
-    char columns[4];
-    char lines[4];
+    char columns[5];
+    char lines[5];
     bool activePager;
 } sessionParameters;
 
@@ -252,8 +252,8 @@ void ios_setWindowSize(int width, int height, const void* sessionId) {
         return;
     }
 
-    sprintf(resizedSession->columns, "%d", width);
-    sprintf(resizedSession->lines, "%d",height);
+    sprintf(resizedSession->columns, "%d", MIN(width, 9999));
+    sprintf(resizedSession->lines, "%d", MIN(height, 9999));
     // Also send SIGWINCH to the main thread of resizedSession:
     if (resizedSession->current_command_root_thread != NULL) {
         pthread_kill(resizedSession->current_command_root_thread, SIGWINCH);


### PR DESCRIPTION
On large displays it is possible to set cols >= 1000. That value doesn't fit allocated char arrays and app crashes.

`columns` and `rows` now 5 char buffers and also added limits to max 9999.