### PR TITLE
Fix arguments parsing with " inside

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -2406,7 +2406,9 @@ static char* getLastCharacterOfArgument(const char* argument) {
                 write[0] = 0;
                 return getLastCharacterOfArgument(endquote + 1);
             }
-            return endquote + 1;
+            // After quote non space character, we should continue till space:
+            // `ssh "user name"@localhost`
+            return nextUnescapedCharacter(endquote + 1, ' ');
         }
         return NULL;
     } else if (argument[0] == '\'') {
@@ -2426,7 +2428,9 @@ static char* getLastCharacterOfArgument(const char* argument) {
                 write[0] = 0;
                 return getLastCharacterOfArgument(endquote);
             }
-            return endquote + 1;
+            // After quote non space character, we should continue till space
+            // `ssh "user name"@localhost`
+            return nextUnescapedCharacter(endquote + 1, ' ');
         }
         return NULL;
     } else if (argument[0] == recordSeparator) {


### PR DESCRIPTION
Hello Nicolas 👋 

This PR partially fix issue with parsing quoted arguments.

For instance,

`ssh "user name"@localhost`
produced [`ssh`, `user name`, `localhost`] argv.

With this PR it will produce [`ssh`, `\"user name\"@localhost`] argv.

Not ideal, but a least we can handle that inside command.

Ideal fix would be to also fix `unquoteArgument` function https://github.com/holzschu/ios_system/blob/6a83eb1c6c383a562fbe33a7e97677e88d305b51/ios_system.m#L2442-L2447

But fix require new allocations, so I decided that this PR is good for the start.