### PR TITLE
Check thread_stdout var before use it in fileno

### DIFF
--- a/ios_system.m
+++ b/ios_system.m
@@ -2005,7 +2005,7 @@ int ios_dup2(int fd1, int fd2)
         child_stdout = fdopen(fd1, "wb");
     } else if (fd2 == 2) {
         if ((child_stdout != NULL) && (fileno(child_stdout) == fd1)) child_stderr = child_stdout;
-        if ((child_stdout != NULL) && (fileno(thread_stdout) == fd1)) child_stderr = child_stdout;
+        if ((thread_stdout != NULL) && (fileno(thread_stdout) == fd1)) child_stderr = child_stdout;
         else if (fd1 == 1) {
             child_stderr = thread_stdout;
         } else child_stderr = fdopen(fd1, "wb");


### PR DESCRIPTION
Hello 👋 

After investigating [PorxyJump issue](https://github.com/blinksh/blink/discussions/1868). I found that code doing wrong check:

https://github.com/holzschu/ios_system/blob/70141fbc072920f3d6232c10abb9da38853fb141/ios_system.m#L2008

It should check `thread_stdout` for NULL.

This PR do proper var check.